### PR TITLE
Prepare for F-Droid inclusion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     repositories {
 		mavenLocal()
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.1'
@@ -18,7 +17,6 @@ allprojects {
     repositories {
 		mavenLocal()
         google()
-        jcenter()
     }
 }
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,9 @@
+Installer and manager of the Dreamland framework.
+NOTE: Dreamland framework is not stable now. If you are a regular user, please don't install it!
+Dreamland is a Xposed framework implementation, you can use it to use Xposed modules.
+<ul>
+<li>Supports Android 5.0~<strong>14</strong></li>
+<li>Low invasiveness</li>
+<li>For hooking third apps, only requires restart the target app, not the device</li>
+<li>Strictly restrict modules, you can choose which apps need to load which modules</li>
+</ul>

--- a/fastlane/metadata/android/en-US/images/icon.png
+++ b/fastlane/metadata/android/en-US/images/icon.png
@@ -1,0 +1,1 @@
+../../../../../app/src/main/res/mipmap-xxxhdpi/ic_launcher.png

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Installer and manager for the Dreamland framework


### PR DESCRIPTION
This PR adds metadata in fastlane structure for F-Droid and removes jcenter since it's deprecated.

I have [prepared the build metadata for F-Droid](https://gitlab.com/linsui/fdroiddata/-/commit/3ce6b8057cbb0d6c4583c3acf2a5b16d130eefe6) and checked that the build is reproducible. So the identical apk with your signature will be published on F-Droid. Does it look good to you?

A new release is needed to make this PR included.