### PR TITLE
Use `ContextCompat.getColor(...)`

### DIFF
--- a/app/src/main/java/top/canyie/dreamland/manager/ui/activities/TroubleShootActivity.java
+++ b/app/src/main/java/top/canyie/dreamland/manager/ui/activities/TroubleShootActivity.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
+import androidx.core.content.ContextCompat;
 
 import java.io.IOException;
 
@@ -85,7 +86,7 @@ public class TroubleShootActivity extends BaseActivity implements ResultCallback
     }
 
     private void appendText(CharSequence text, boolean error) {
-        final ForegroundColorSpan colorSpan = error ? new ForegroundColorSpan(getColor(R.color.color_error)) : null;
+        final ForegroundColorSpan colorSpan = error ? new ForegroundColorSpan(ContextCompat.getColor(this, R.color.color_error)) : null;
         Threads.execOnMainThread(() -> {
             Editable editable = mConsole.getEditableText();
             if (colorSpan != null) {

--- a/app/src/main/java/top/canyie/dreamland/manager/ui/adapters/MaseListAdapter.java
+++ b/app/src/main/java/top/canyie/dreamland/manager/ui/adapters/MaseListAdapter.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SwitchCompat;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
@@ -85,7 +86,7 @@ public class MaseListAdapter extends RecyclerView.Adapter implements Filterable 
             if (appInfo.required) {
                 itemHolder.appNotice.setVisibility(View.VISIBLE);
                 itemHolder.appNotice.setText(R.string.required_for_module);
-                itemHolder.appNotice.setTextColor(mCtx.getColor(R.color.colorAccent));
+                itemHolder.appNotice.setTextColor(ContextCompat.getColor(mCtx, R.color.colorAccent));
             } else {
                 itemHolder.appNotice.setVisibility(View.GONE);
             }

--- a/app/src/main/java/top/canyie/dreamland/manager/ui/fragments/StatusFragment.java
+++ b/app/src/main/java/top/canyie/dreamland/manager/ui/fragments/StatusFragment.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.cardview.widget.CardView;
+import androidx.core.content.ContextCompat;
 
 import top.canyie.dreamland.manager.R;
 import top.canyie.dreamland.manager.core.DownloadChannel;
@@ -203,15 +204,15 @@ public class StatusFragment extends PageFragment
             cardBackgroundColorRes = normal ? R.color.color_active :
                     warning ? R.color.color_warning : R.color.color_error;
         }
-        statusCardBackground.setBackgroundColor(statusCardBackground.getContext().getColor(cardBackgroundColorRes));
+        statusCardBackground.setBackgroundColor(ContextCompat.getColor(statusCardBackground.getContext(), cardBackgroundColorRes));
         statusImage.setImageResource(cardImageRes);
 
         if (info.checkVerifiedBootFailed) {
             verifiedBootStateText.setText(R.string.verified_boot_state_unknown);
-            verifiedBootStateText.setTextColor(requireContext().getColor(R.color.color_error));
+            verifiedBootStateText.setTextColor(ContextCompat.getColor(requireContext(), R.color.color_error));
         } else if (info.isVerifiedBootActive) {
             verifiedBootStateText.setText(R.string.verified_boot_state_active);
-            verifiedBootStateText.setTextColor(requireContext().getColor(R.color.color_error));
+            verifiedBootStateText.setTextColor(ContextCompat.getColor(requireContext(), R.color.color_error));
         } else if (info.detectVerifiedBoot) {
             verifiedBootStateText.setText(R.string.verified_boot_state_deactivated);
         } else {
@@ -225,7 +226,7 @@ public class StatusFragment extends PageFragment
             } else {
                 selinuxStatusLinearLayoutParams.height = 2 * dimenDeviceInfoItemHeight;
                 seLinuxModeText.setText(R.string.selinux_mode_permissive);
-                seLinuxModeText.setTextColor(requireContext().getColor(R.color.color_error_dark));
+                seLinuxModeText.setTextColor(ContextCompat.getColor(requireContext(), R.color.color_error_dark));
             }
         } else {
             seLinuxModeText.setText(R.string.selinux_mode_disabled);


### PR DESCRIPTION
使用梦境管理器时在安卓5。1。1上时将会获得错误：
```
E/AndroidRuntime(12565): java.lang.NoSuchMethodError: No virtual method getColor(I)I in class Landroid/content/Context; or its super classes (declaration of 'android.content.Context' appears in /system/framework/framework.jar:classes2.dex)
E/AndroidRuntime(12565): 	at top.canyie.dreamland.manager.ui.fragments.StatusFragment.updateUIForData(StatusFragment.java:206)
```
已将`getColor`方法替换为`ContextCompat.getColor`来修复此问题）已修复（。  
注释：需要删除`module/system.prop`的`dalvik.vm.dex2oat-flags=--inline-max-code-units=0`以使安卓5。1。1做梦。此参数已在安卓6中被介绍。
编辑：我感到抱歉，只是认识到日志已被翻译＝）